### PR TITLE
fixed os.startfile issue, and added .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+downloaded_videos

--- a/youtube_downloads.py
+++ b/youtube_downloads.py
@@ -10,6 +10,7 @@
 from pytube import YouTube
 from pytube import Playlist
 import os
+import subprocess
 link = 'https://youtu.be/umDr0mPuyQc'
 
 video = YouTube(link)
@@ -42,9 +43,22 @@ video = YouTube(link)
 selected_path = "./downloaded_videos"
 
 
+# credit:
+# https://stackoverflow.com/questions/2878712/make-os-open-directory-in-python
+def startfile(filename):
+    try:
+        os.startfile(filename)
+    except:
+        try:
+            subprocess.Popen(['xdg-open', filename])
+        except:
+            # i think we are on mac
+            subprocess.Popen(['open', filename])
+
+
 def finish():
     path = os.path.realpath(selected_path)
-    os.startfile(path)
+    startfile(path)
     print('Download Done')
 
 


### PR DESCRIPTION
The new `startfile()` function tries to open the folder. If it fails, then we aren't on Windows, and it uses `xdg-open` command from linux, and if it fails, it uses `open` command from macOS.

The `.gitignore` file is to just ignore the videos folder in code editors and IDEs.
(forgot to add it in the previous pull request)